### PR TITLE
New design for minimal file count of a squirrels project

### DIFF
--- a/squirrels/__init__.py
+++ b/squirrels/__init__.py
@@ -1,5 +1,5 @@
 from .param_configs.parameter_options import SelectParameterOption, DateParameterOption, NumberParameterOption, NumRangeParameterOption
-from .param_configs.parameters import WidgetType, Parameter, SingleSelectParameter, MultiSelectParameter, DateParameter, NumberParameter, NumRangeParameter
+from .param_configs.parameters import Parameter, SingleSelectParameter, MultiSelectParameter, DateParameter, NumberParameter, NumRangeParameter
 from .param_configs.data_sources import SelectionDataSource, DateDataSource, NumberDataSource, NumRangeDataSource, DataSourceParameter
 from .param_configs.parameter_set import ParameterSet
 from .connection_set import ConnectionSet

--- a/squirrels/_command_line.py
+++ b/squirrels/_command_line.py
@@ -45,11 +45,11 @@ def main():
     def _add_profile_argument(parser: ArgumentParser):
         parser.add_argument('key', type=str, help='Key to the database connection credential')
 
-    subparsers.add_parser(c.GET_CREDS_CMD, help='Get all database connection credential keys')
-
     set_cred_parser = subparsers.add_parser(c.SET_CRED_CMD, help='Set a database connection credential key')
     _add_profile_argument(set_cred_parser)
     set_cred_parser.add_argument('--values', type=str, nargs=2, help='The username and password')
+
+    subparsers.add_parser(c.GET_CREDS_CMD, help='Get all database connection credential keys')
 
     delete_cred_parser = subparsers.add_parser(c.DELETE_CRED_CMD, help='Delete a database connection credential key')
     _add_profile_argument(delete_cred_parser)
@@ -77,11 +77,11 @@ def main():
     elif args.command == c.LOAD_MODULES_CMD:
         manifest = mf.from_file()
         ml.load_modules(manifest)
-    elif args.command == c.GET_CREDS_CMD: 
-        cm.squirrels_config_io.print_all_credentials()
     elif args.command == c.SET_CRED_CMD:
         user, pw = _prompt_user_pw(args.values)
         cm.squirrels_config_io.set_credential(args.key, user, pw)
+    elif args.command == c.GET_CREDS_CMD: 
+        cm.squirrels_config_io.print_all_credentials()
     elif args.command == c.DELETE_CRED_CMD:
         cm.squirrels_config_io.delete_credential(args.key)
     elif args.command in [c.RUN_CMD, c.TEST_CMD]:

--- a/squirrels/_command_line.py
+++ b/squirrels/_command_line.py
@@ -33,11 +33,12 @@ def main():
     init_parser = subparsers.add_parser(c.INIT_CMD, help='Initialize a squirrels project')
     init_parser.add_argument('--no-overwrite', action='store_true', help="Don't overwrite files if they already exist")
     init_parser.add_argument('--core', action='store_true', help='Include all core files')
+    init_parser.add_argument('--db-view', type=str, choices=c.FILE_TYPE_CHOICES, help='Create database view as sql (default) or python file if "--core" is specified')
+    init_parser.add_argument('--connections', action='store_true', help=f'Include the {c.CONNECTIONS_FILE} file')
     init_parser.add_argument('--context', action='store_true', help=f'Include the {c.CONTEXT_FILE} file')
     init_parser.add_argument('--selections-cfg', action='store_true', help=f'Include the {c.SELECTIONS_CFG_FILE} file')
-    init_parser.add_argument('--db-view', type=str, choices=['sql', 'py'], help='Create database view as sql (default) or python file')
-    init_parser.add_argument('--final-view', type=str, choices=['sql', 'py'], help='Include final view as sql or python file')
-    init_parser.add_argument('--sample-db', type=str, choices=['seattle-weather'], help='Sample sqlite database to include')
+    init_parser.add_argument('--final-view', type=str, choices=c.FILE_TYPE_CHOICES, help='Include final view as sql or python file')
+    init_parser.add_argument('--sample-db', type=str, choices=c.DATABASE_CHOICES, help='Sample sqlite database to include')
 
     subparsers.add_parser(c.LOAD_MODULES_CMD, help='Load all the modules specified in squirrels.yaml from git')
 

--- a/squirrels/constants.py
+++ b/squirrels/constants.py
@@ -8,14 +8,19 @@ TEST_CMD = 'test'
 RUN_CMD = 'run'
 
 # Manifest file keys
+PROJ_VARS_KEY = 'project_variables'
+PRODUCT_KEY = 'product'
+MAJOR_VERSION_KEY = 'major_version'
+DB_CONNECTIONS_KEY = 'db_connections'
+DB_CREDENTIALS_KEY = 'credential_key'
+URL_KEY = 'url'
 DB_CONNECTION_KEY = 'db_connection'
 MODULES_KEY = 'modules'
 DATASET_LABEL_KEY = 'label'
 DATASETS_KEY = 'datasets'
 HEADERS_KEY = 'headers'
 DATABASE_VIEWS_KEY = 'database_views'
-DB_VIEW_NAME_KEY = 'name'
-DB_VIEW_FILE_KEY = 'file'
+FILE_KEY = 'file'
 FINAL_VIEW_KEY = 'final_view'
 BASE_PATH_KEY = 'base_path'
 SETTINGS_KEY = 'settings'
@@ -24,10 +29,10 @@ SETTINGS_KEY = 'settings'
 CREDENTIALS_KEY = 'credentials'
 USERNAME_KEY = 'username'
 PASSWORD_KEY = 'password'
+DEFAULT_DB_CONN = 'default'
 
 # Folder/File names
 MANIFEST_FILE = 'squirrels.yaml'
-PROJ_VARS_FILE = 'project_vars.yaml'
 CONNECTIONS_FILE = 'connections.py'
 OUTPUTS_FOLDER = 'outputs'
 MODULES_FOLDER = 'modules'
@@ -50,4 +55,7 @@ RESULTS_CACHE_TTL_SETTING = 'results.cache.ttl'
 
 # Selection cfg sections
 PARAMETERS_SECTION = 'parameters'
-HEADERS_SECTION = 'headers'
+
+# Init Command Choices
+FILE_TYPE_CHOICES = ['sql', 'py']
+DATABASE_CHOICES = ['sample_database', 'seattle_weather']

--- a/squirrels/manifest.py
+++ b/squirrels/manifest.py
@@ -1,63 +1,66 @@
 from typing import List, Dict, Any, Optional, Union
 from pathlib import Path
+from sqlalchemy import Engine, create_engine
 import yaml
 
 from squirrels import constants as c, utils
+from squirrels.credentials_manager import Credential, squirrels_config_io
 from squirrels.utils import ConfigurationError, InvalidInputError
-from squirrels.timed_imports import jinja2 as j2
 
 
 class Manifest:
-    def __init__(self, parms: Dict, proj_vars: Dict[str, str] = {}) -> None:
+    def __init__(self, parms: Dict) -> None:
         self._parms = parms
-        self._proj_vars = proj_vars
     
     @classmethod
-    def from_yaml_str(cls, parms_str: str, proj_vars_str: str = ''):
-        proj_vars_str = proj_vars_str.rstrip()
-        if proj_vars_str != '':
-            proj_vars = yaml.safe_load(proj_vars_str)
-            template = utils.j2_env.from_string(parms_str)
-            rendered = template.render(**proj_vars)
-        else:
-            proj_vars = {}
-            rendered = parms_str
-        parms = yaml.safe_load(rendered)
-        return cls(parms, proj_vars)
+    def from_yaml_str(cls, parms_str: str):
+        parms = yaml.safe_load(parms_str)
+        return cls(parms)
 
     @classmethod
-    def from_file(cls, manifest_path: str, project_vars_path: str):
-        try:
-            with open(project_vars_path, 'r') as f:
-                proj_vars_str = f.read()
-        except FileNotFoundError:
-            proj_vars_str = ''
-            
+    def from_file(cls, manifest_path: str):
         with open(manifest_path, 'r') as f:
             parms_str = f.read()
         
-        return Manifest.from_yaml_str(parms_str, proj_vars_str)
+        return Manifest.from_yaml_str(parms_str)
     
-    def get_parms(self):
-        return self._parms
+    def get_proj_vars(self) -> Dict[str, Any]:
+        return self._parms.get(c.PROJ_VARS_KEY, dict())
     
-    def get_proj_vars(self):
-        return self._proj_vars
-    
-    def get_modules(self):
+    def get_modules(self) -> List[str]:
         return self._parms.get(c.MODULES_KEY, list())
     
-    def _get_required_field(self, key: str):
+    def _get_required_field(self, key: str) -> Any:
         try:
             return self._parms[key]
         except KeyError as e:
             raise ConfigurationError(f'Field "{key}" not found in squirrels.yaml') from e
     
     def get_base_path(self) -> str:
-        return self._get_required_field(c.BASE_PATH_KEY)
+        project_vars = self.get_proj_vars()
+        try:
+            product = project_vars[c.PRODUCT_KEY]
+            major_version = project_vars[c.MAJOR_VERSION_KEY]
+        except KeyError as e:
+            raise ConfigurationError("Could not construct API endpoint as 'product' and 'major_version' \
+                                     were not specified in project variables") from e
+        base_path = f"/{product}/v{major_version}"
+        return base_path
     
-    def get_default_db_connection(self) -> Optional[str]:
-        return self._parms.get(c.DB_CONNECTION_KEY, None)
+    def get_db_connections(self, test_creds: Dict[str, Credential] = None) -> Dict[str, Engine]:
+        configs: Dict[str, Dict[str, str]] = self._parms.get(c.DB_CONNECTIONS_KEY, {})
+        output = {}
+        for key, config in configs.items():
+            cred_key = config.get(c.DB_CREDENTIALS_KEY)
+            if cred_key is None:
+                cred = Credential("", "")
+            elif test_creds is not None:
+                cred = test_creds[cred_key]
+            else:
+                cred = squirrels_config_io.get_credential(cred_key)
+            url = config[c.URL_KEY].replace("${username}", cred.username).replace("${password}", cred.password)
+            output[key] = create_engine(url)
+        return output
 
     def _get_dataset_parms(self, dataset: str) -> Dict[str, Any]:
         try:
@@ -69,7 +72,7 @@ class Manifest:
         try:
             return self._get_dataset_parms(dataset)[key]
         except KeyError as e:
-            raise ConfigurationError(f'The "{key}" field is not defined for dataset "{dataset}"')
+            raise ConfigurationError(f'The "{key}" field is not defined for dataset "{dataset}"') from e
     
     def _get_all_database_view_parms(self, dataset: str) -> Dict[str, Dict[str, str]]:
         return self._get_required_field_from_dataset_parms(dataset, c.DATABASE_VIEWS_KEY)
@@ -80,6 +83,11 @@ class Manifest:
     
     def get_dataset_folder(self, dataset: str) -> Path:
         return utils.join_paths(c.DATASETS_FOLDER, dataset)
+        
+    def get_dataset_args(self, dataset: str) -> Dict[str, Any]:
+        dataset_args = self._get_dataset_parms(dataset).get("args", {})
+        full_args = {**self.get_proj_vars(), **dataset_args}
+        return full_args
     
     def get_all_database_view_names(self, dataset: str) -> List[str]:
         all_database_views = self._get_all_database_view_parms(dataset)
@@ -87,32 +95,53 @@ class Manifest:
     
     def get_database_view_file(self, dataset: str, database_view: str) -> Path:
         database_view_parms = self._get_all_database_view_parms(dataset)[database_view]
-        try:
-            db_view_file = database_view_parms[c.DB_VIEW_FILE_KEY]
-        except KeyError as e:
-            raise ConfigurationError(f'The "{c.DB_VIEW_FILE_KEY}" field is not defined for "{database_view}" in dataset "{dataset}"') from e
+        if isinstance(database_view_parms, str):
+            db_view_file = database_view_parms
+        else:
+            try:
+                db_view_file = database_view_parms[c.FILE_KEY]
+            except KeyError as e:
+                raise ConfigurationError(f'The "{c.FILE_KEY}" field is not defined for "{database_view}" in dataset "{dataset}"') from e
         dataset_folder = self.get_dataset_folder(dataset)
         return utils.join_paths(dataset_folder, db_view_file)
+    
+    def get_view_args(self, dataset: str, database_view: str = None) -> Dict[str, Any]:
+        dataset_args = self.get_dataset_args(dataset)
+        if database_view is None:
+            view_parms: Dict[str, Any] = self._get_required_field_from_dataset_parms(dataset, c.FINAL_VIEW_KEY)
+        else:
+            view_parms: Dict[str, Any] = self._get_all_database_view_parms(dataset)[database_view]
+        view_args: Dict[str, Any] = {} if isinstance(view_parms, str) else view_parms.get("args", {})
+        full_args = {**dataset_args, **view_args}
+        return full_args
 
-    def get_database_view_db_connection(self, dataset: str, database_view: str) -> str:
+    def get_database_view_db_connection(self, dataset: str, database_view: str) -> Optional[str]:
         database_view_parms = self._get_all_database_view_parms(dataset)[database_view]
-        try:
-            db_connection = database_view_parms.get(c.DB_CONNECTION_KEY, None)
-            return db_connection if db_connection is not None else self._parms[c.DB_CONNECTION_KEY]
-        except KeyError as e:
-            raise ConfigurationError(f'Undefined database profile for "{database_view}" in dataset "{dataset}"') from e
+        if isinstance(database_view_parms, str):
+            db_connection = c.DEFAULT_DB_CONN 
+        else: 
+            db_connection = database_view_parms.get(c.DB_CONNECTION_KEY, c.DEFAULT_DB_CONN)
+        return db_connection
     
     def get_dataset_label(self, dataset: str) -> str:
         return self._get_required_field_from_dataset_parms(dataset, c.DATASET_LABEL_KEY)
     
-    def get_dataset_final_view(self, dataset: str) -> Union[str, Path]:
-        final_view = self._get_required_field_from_dataset_parms(dataset, c.FINAL_VIEW_KEY)
+    def get_dataset_final_view_file(self, dataset: str) -> Union[str, Path]:
+        final_view_parms: Dict[str, Any] = self._get_required_field_from_dataset_parms(dataset, c.FINAL_VIEW_KEY)
+        if isinstance(final_view_parms, str):
+            final_view_file = final_view_parms
+        else:
+            try:
+                final_view_file = final_view_parms[c.FILE_KEY]
+            except KeyError as e:
+                raise ConfigurationError(f'The "{c.FILE_KEY}" field is not defined for the final view') from e
+        
         database_views = self.get_all_database_view_names(dataset)
-        if final_view in database_views:
-            return final_view
+        if final_view_file in database_views:
+            return final_view_file
         else:
             dataset_path = self.get_dataset_folder(dataset)
-            return utils.join_paths(dataset_path, final_view)
+            return utils.join_paths(dataset_path, final_view_file)
 
     def get_setting(self, key: str, default: Any) -> Any:
         settings: Dict[str, Any] = self._parms.get(c.SETTINGS_KEY, dict())
@@ -120,4 +149,4 @@ class Manifest:
 
 
 def from_file():
-    return Manifest.from_file(c.MANIFEST_FILE, c.PROJ_VARS_FILE)
+    return Manifest.from_file(c.MANIFEST_FILE)

--- a/squirrels/package_data/base_project/connections.py
+++ b/squirrels/package_data/base_project/connections.py
@@ -1,11 +1,11 @@
-from typing import Dict
-from sqlalchemy import create_engine, QueuePool
+from typing import Dict, Union, Any
+from sqlalchemy import create_engine, QueuePool, Engine, Pool
 
-from squirrels import ConnectionSet, get_credential
+from squirrels import get_credential
 
 
 # Note: all connections must be shareable across multiple thread. No writes will occur on them
-def main(proj: Dict[str, str], *args, **kwargs) -> ConnectionSet:
+def main(proj: Dict[str, Any], *p_args, **kwargs) -> Dict[str, Union[Engine, Pool]]:
 
     # ## Example of getting the username and password set with "$ squirrels set-credential [key]"
     # cred = get_credential('my_key')
@@ -14,8 +14,8 @@ def main(proj: Dict[str, str], *args, **kwargs) -> ConnectionSet:
     # Create a connection pool / engine
     pool = create_engine('sqlite:///./database/sample_database.db')
 
-    # ## Example of using QueuePool instead with a custom db connector:
+    # ## Example of using QueuePool instead for a custom db connector:
     # connection_creator = lambda: sqlite3.connect('./database/sample_database.db', check_same_thread=False)
     # pool = QueuePool(connection_creator)
     
-    return ConnectionSet({'my_db': pool})
+    return {'default': pool}

--- a/squirrels/package_data/base_project/datasets/sample_dataset/context.py
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/context.py
@@ -2,7 +2,7 @@ from typing import Dict, Any
 import squirrels as sq
 
 
-def main(prms: sq.ParameterSet, proj: Dict[str, Any], *p_args, **kwargs) -> Dict[str, Any]:
+def main(prms: sq.ParameterSet, args: Dict[str, Any], *p_args, **kwargs) -> Dict[str, Any]:
     limit_parameter: sq.NumberParameter = prms['upper_bound']
     limit: str = limit_parameter.get_selected_value()
     return {'limit': limit}

--- a/squirrels/package_data/base_project/datasets/sample_dataset/context.py
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/context.py
@@ -2,7 +2,7 @@ from typing import Dict, Any
 import squirrels as sq
 
 
-def main(prms: sq.ParameterSet, proj: Dict[str, str], *args, **kwargs) -> Dict[str, Any]:
+def main(prms: sq.ParameterSet, proj: Dict[str, Any], *p_args, **kwargs) -> Dict[str, Any]:
     limit_parameter: sq.NumberParameter = prms['upper_bound']
     limit: str = limit_parameter.get_selected_value()
     return {'limit': limit}

--- a/squirrels/package_data/base_project/datasets/sample_dataset/database_view1.py
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/database_view1.py
@@ -1,13 +1,15 @@
-from typing import Dict, Union, Any
-import sqlalchemy as sa
+from typing import Dict, Any
 import pandas as pd
 
 import squirrels as sq
 
 
-def main(connection_pool: Union[sa.Engine, sa.Pool], connection_set: sq.ConnectionSet,
-         prms: sq.ParameterSet, ctx: Dict[str, Any], proj: Dict[str, str], *args, **kwargs) -> pd.DataFrame:
-    # conn = connection_pool.connect() # use this to create the corresponding DBAPI2 connection
+def main(connection_set: sq.ConnectionSet, 
+         prms: sq.ParameterSet, ctx: Dict[str, Any], args: Dict[str, Any], 
+         *p_args, **kwargs) -> pd.DataFrame:
+    # pool = connection_set.get_connection_pool("default")
+    # conn = pool.connect() # use this to get a DBAPI connection from a Pool or sqlalchemy connection from an Engine
+    # conn = pool.raw_connection() # use this to get a DBAPI connection from an Engine
     
     df = pd.DataFrame({
         'dim1': ['a', 'b', 'c', 'd', 'e', 'f'], 

--- a/squirrels/package_data/base_project/datasets/sample_dataset/database_view1.sql.j2
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/database_view1.sql.j2
@@ -1,3 +1,5 @@
+-- %USE some_db -- TBA: this line is optional when connecting to the "default" db_connection
+
 -- note: if context.py is defined, you can use "ctx['limit']" instead of "prms['number_example'].get_selected_value()"
 SELECT dim1, avg(metric1) as metric1, avg(metric2) as metric2
 FROM fact_table

--- a/squirrels/package_data/base_project/datasets/sample_dataset/database_view1.sql.j2
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/database_view1.sql.j2
@@ -3,5 +3,5 @@
 -- note: if context.py is defined, you can use "ctx['limit']" instead of "prms['number_example'].get_selected_value()"
 SELECT dim1, avg(metric1) as metric1, avg(metric2) as metric2
 FROM fact_table
-WHERE metric1 <= {{ prms['upper_bound'].get_selected_value() }} 
+WHERE metric1 <= {{ prms['upper_bound'].get_selected_value() }}
 GROUP BY dim1

--- a/squirrels/package_data/base_project/datasets/sample_dataset/final_view.py
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/final_view.py
@@ -4,7 +4,7 @@ import squirrels as sq
 
 
 def main(database_views: Dict[str, pd.DataFrame], 
-         prms: sq.ParameterSet, ctx: Dict[str, Any], args: Dict[str, Any], 
+         prms: sq.ParameterSet, ctx: Dict[str, Any], proj: Dict[str, Any], 
          *p_args, **kwargs) -> pd.DataFrame:
     df = database_views['database_view1']
     return df

--- a/squirrels/package_data/base_project/datasets/sample_dataset/final_view.py
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/final_view.py
@@ -3,7 +3,8 @@ import pandas as pd
 import squirrels as sq
 
 
-def main(database_views: Dict[str, pd.DataFrame], prms: sq.ParameterSet, 
-         ctx: Dict[str, Any], proj: Dict[str, str], *args, **kwargs) -> pd.DataFrame:
+def main(database_views: Dict[str, pd.DataFrame], 
+         prms: sq.ParameterSet, ctx: Dict[str, Any], args: Dict[str, Any], 
+         *p_args, **kwargs) -> pd.DataFrame:
     df = database_views['database_view1']
     return df

--- a/squirrels/package_data/base_project/datasets/sample_dataset/parameters.py
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/parameters.py
@@ -2,7 +2,7 @@ from typing import Dict, Any
 import squirrels as sq
 
 
-def main(*p_args, **kwargs) -> sq.ParameterSet:
+def main(args: Dict[str, Any], *p_args, **kwargs) -> sq.ParameterSet:
     single_select_options = (
         sq.SelectParameterOption('a0', 'Primary Colors'),
         sq.SelectParameterOption('a1', 'Secondary Colors')

--- a/squirrels/package_data/base_project/datasets/sample_dataset/parameters.py
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/parameters.py
@@ -1,7 +1,8 @@
+from typing import Dict, Any
 import squirrels as sq
 
 
-def main(*args, **kwargs) -> sq.ParameterSet:
+def main(*p_args, **kwargs) -> sq.ParameterSet:
     single_select_options = (
         sq.SelectParameterOption('a0', 'Primary Colors'),
         sq.SelectParameterOption('a1', 'Secondary Colors')

--- a/squirrels/package_data/base_project/datasets/sample_dataset/parameters.py
+++ b/squirrels/package_data/base_project/datasets/sample_dataset/parameters.py
@@ -9,10 +9,10 @@ def main(args: Dict[str, Any], *p_args, **kwargs) -> sq.ParameterSet:
     )
     
     multi_select_options = (
-        sq.SelectParameterOption('x0', 'Red', parent_option_id='a0'),
+        sq.SelectParameterOption('x0', 'Red',    parent_option_id='a0'),
         sq.SelectParameterOption('x1', 'Yellow', parent_option_id='a0'),
-        sq.SelectParameterOption('x2', 'Blue', parent_option_id='a0'),
-        sq.SelectParameterOption('x3', 'Green', parent_option_id='a1'),
+        sq.SelectParameterOption('x2', 'Blue',   parent_option_id='a0'),
+        sq.SelectParameterOption('x3', 'Green',  parent_option_id='a1'),
         sq.SelectParameterOption('x4', 'Orange', parent_option_id='a1'),
         sq.SelectParameterOption('x5', 'Purple', parent_option_id='a1')
     )

--- a/squirrels/package_data/base_project/project_vars.yaml
+++ b/squirrels/package_data/base_project/project_vars.yaml
@@ -1,3 +1,0 @@
-product: myproduct
-major_version: 0
-minor_version: 1

--- a/squirrels/package_data/base_project/squirrels.yaml
+++ b/squirrels/package_data/base_project/squirrels.yaml
@@ -1,15 +1,26 @@
 modules: []
 
-db_connection: my_db
+project_variables:
+  # product, major_version, and minor_version are required project variables
+  product: sample
+  major_version: 1
+  minor_version: 0
+  # additional project variables can be added here
 
-base_path: "/v{{major_version}}"
+db_connections: # optional if connections.py exists
+  default: 
+    credential_key: null # optional if null
+    url: 'sqlite://${username}:${password}@/./database/sample_database.db'
 
 datasets:
   sample_dataset:
     label: Sample Dataset
     database_views:
-      database_view1:
+      database_view1: 
         file: database_view1.sql.j2
-    final_view: final_view.sql.j2
+        db_connection: default # optional if default
+        args: {} # optional if empty
+    final_view: database_view1
+    args: {} # optional if empty
 
 settings: {}

--- a/squirrels/package_data/static/script.js
+++ b/squirrels/package_data/static/script.js
@@ -65,7 +65,7 @@ function refreshParameters(provoker = null) {
                 newDiv.appendChild(paramLabel)
             }
 
-            if (param.widget_type === "DateField") {
+            if (param.widget_type === "DateParameter") {
                 addLabel()
                 const dateInput = document.createElement('input')
                 dateInput.type = 'date'
@@ -73,7 +73,7 @@ function refreshParameters(provoker = null) {
                 dateInput.value = param.selected_date
                 dateInput.onchange = updateParameter
                 newDiv.appendChild(dateInput)
-            } else if (param.widget_type === "NumberField") {
+            } else if (param.widget_type === "NumberParameter") {
                 addLabel()
                 const sliderInput = document.createElement('input')
                 sliderInput.type = 'range'
@@ -95,9 +95,9 @@ function refreshParameters(provoker = null) {
 
                 newDiv.appendChild(sliderInput)
                 newDiv.appendChild(sliderValue)
-            } else if (param.widget_type === "RangeField") {
+            } else if (param.widget_type === "NumRangeParameter") {
                 // TODO
-            } else if (param.widget_type === "SingleSelect" && param.options.length > 0) {
+            } else if (param.widget_type === "SingleSelectParameter" && param.options.length > 0) {
                 addLabel()
                 const singleSelect = document.createElement('select');
                 singleSelect.id = param.name;
@@ -112,7 +112,7 @@ function refreshParameters(provoker = null) {
                 });
                 singleSelect.onchange = updateParameter
                 newDiv.appendChild(singleSelect);
-            } else if (param.widget_type === "MultiSelect" && param.options.length > 0) {
+            } else if (param.widget_type === "MultiSelectParameter" && param.options.length > 0) {
                 addLabel()
                 const multiSelect = document.createElement('select');
                 multiSelect.id = param.name;
@@ -136,15 +136,15 @@ function refreshParameters(provoker = null) {
 
 function updateParameter() {
     const param = parametersMap.get(this.id)
-    if (param.widget_type === "DateField") {
+    if (param.widget_type === "DateParameter") {
         param.selected_date = this.value
-    } else if (param.widget_type === "NumberField") {
+    } else if (param.widget_type === "NumberParameter") {
         param.selected_value = this.value
-    } else if (param.widget_type === "RangeField") {
+    } else if (param.widget_type === "NumRangeParameter") {
         // TODO
-    } else if (param.widget_type === "SingleSelect") {
+    } else if (param.widget_type === "SingleSelectParameter") {
         param.selected_id = this.options[this.selectedIndex].value
-    } else if (param.widget_type === "MultiSelect") {
+    } else if (param.widget_type === "MultiSelectParameter") {
         param.selected_ids = [...this.selectedOptions].map(option => option.value)
     }
     
@@ -156,15 +156,15 @@ function updateParameter() {
 function getQueryParams(provoker = null) {
     const queryParams = {}
     function addToQueryParams(key, value) {
-        if (value.widget_type === "DateField") {
+        if (value.widget_type === "DateParameter") {
             queryParams[key] = value.selected_date
-        } else if (value.widget_type === "NumberField") {
+        } else if (value.widget_type === "NumberParameter") {
             queryParams[key] = value.selected_value
-        } else if (value.widget_type === "RangeField") {
+        } else if (value.widget_type === "NumRangeParameter") {
             // TODO
-        } else if (value.widget_type === "SingleSelect") {
+        } else if (value.widget_type === "SingleSelectParameter") {
             queryParams[key] = value.selected_id
-        } else if (value.widget_type === "MultiSelect") {
+        } else if (value.widget_type === "MultiSelectParameter") {
             result = value.selected_ids.join()
             if (result !== '') queryParams[key] = result
         }

--- a/squirrels/param_configs/data_sources.py
+++ b/squirrels/param_configs/data_sources.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from squirrels.param_configs import parameters as p, parameter_options as po
 from squirrels.timed_imports import pandas as pd
-from squirrels import utils
+from squirrels import utils, constants as c
 
 
 @dataclass
@@ -12,12 +12,13 @@ class DataSource:
     """
     Abstract class for lookup tables coming from a database
     """
-    connection_name: str
     table_or_query: str
     
     def __post_init__(self) -> None:
         if not hasattr(self, 'parent_id_col'):
             self.parent_id_col = None
+        if not hasattr(self, 'connection_name'):
+            self.connection_name = c.DEFAULT_DB_CONN
 
     def get_query(self) -> str:
         """
@@ -73,6 +74,7 @@ class SelectionDataSource(DataSource):
     order_by_col: Optional[str] = None
     is_default_col: Optional[str] = None
     parent_id_col: Optional[str] = None
+    connection_name: str = c.DEFAULT_DB_CONN
 
     def __post_init__(self):
         self.order_by_col = self.order_by_col if self.order_by_col is not None else self.id_col
@@ -127,6 +129,7 @@ class DateDataSource(DataSource):
     default_date_col: str
     parent_id_col: Optional[str] = None
     date_format: Optional[str] = '%Y-%m-%d'
+    connection_name: str = c.DEFAULT_DB_CONN
 
     def convert(self, ds_param: DataSourceParameter, df: pd.DataFrame) -> p.DateParameter:
         """
@@ -188,6 +191,7 @@ class NumberDataSource(_NumericDataSource):
     """
     default_value_col: Optional[str] = None
     parent_id_col: Optional[str] = None
+    connection_name: str = c.DEFAULT_DB_CONN
 
     def convert(self, ds_param: DataSourceParameter, df: pd.DataFrame) -> p.NumberParameter:
         """
@@ -240,6 +244,7 @@ class NumRangeDataSource(_NumericDataSource):
     default_lower_value_col: Optional[str] = None
     default_upper_value_col: Optional[str] = None
     parent_id_col: Optional[str] = None
+    connection_name: str = c.DEFAULT_DB_CONN
 
     def convert(self, ds_param: DataSourceParameter, df: pd.DataFrame) -> p.NumRangeParameter:
         """

--- a/squirrels/param_configs/parameters.py
+++ b/squirrels/param_configs/parameters.py
@@ -3,7 +3,6 @@ from typing import Sequence, Dict, List, Iterator, Optional, Union
 from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
 from decimal import Decimal
 import copy
 
@@ -11,17 +10,8 @@ from squirrels.param_configs import parameter_options as po
 from squirrels.utils import InvalidInputError, ConfigurationError, AbstractMethodCallError
 
 
-class WidgetType(Enum):
-    SingleSelect = 1
-    MultiSelect = 2
-    DateField = 3
-    NumberField = 4
-    RangeField = 5
-
-
 @dataclass
 class Parameter:
-    widget_type: WidgetType
     name: str
     label: str
     all_options: Sequence[po.ParameterOption]
@@ -90,7 +80,7 @@ class Parameter:
 
     def to_dict(self) -> Dict:
         return {
-            'widget_type': self.widget_type.name,
+            'widget_type': self.__class__.__name__,
             'name': self.name,
             'label': self.label
         }
@@ -146,7 +136,7 @@ class SingleSelectParameter(_SelectionParameter):
 
     def __init__(self, name: str, label: str, all_options: Sequence[po.SelectParameterOption], *, 
                  is_hidden: bool = False, parent: Optional[_SelectionParameter] = None) -> None:
-        super().__init__(WidgetType.SingleSelect, name, label, all_options, is_hidden, parent)
+        super().__init__(name, label, all_options, is_hidden, parent)
     
     def with_selection(self, selection: str) -> SingleSelectParameter:
         param_copy = copy.copy(self)
@@ -196,7 +186,7 @@ class MultiSelectParameter(_SelectionParameter):
 
     def __init__(self, name: str, label: str, all_options: Sequence[po.SelectParameterOption], *, is_hidden = False,
                  parent: Optional[_SelectionParameter] = None, include_all: bool = True, order_matters: bool = False) -> None:
-        super().__init__(WidgetType.MultiSelect, name, label, all_options, is_hidden, parent)
+        super().__init__(name, label, all_options, is_hidden, parent)
         self.include_all = include_all
         self.order_matters = order_matters
 
@@ -264,7 +254,7 @@ class DateParameter(Parameter):
                  *, is_hidden: bool = False) -> None:
         self.curr_option = po.DateParameterOption(default_date, date_format)
         all_options = (self.curr_option,)
-        super().__init__(WidgetType.DateField, name, label, all_options, is_hidden, None)
+        super().__init__(name, label, all_options, is_hidden, None)
         self._set_default_as_selection_mutate()
     
     @staticmethod
@@ -317,7 +307,7 @@ class NumberParameter(_NumericParameter):
         default_value = default_value if default_value is not None else min_value
         curr_option = po.NumberParameterOption(min_value, max_value, increment, default_value)
         all_options = (curr_option,)
-        super().__init__(WidgetType.NumberField, name, label, all_options, is_hidden, None, curr_option)
+        super().__init__(name, label, all_options, is_hidden, None, curr_option)
         self._set_default_as_selection_mutate()
     
     @staticmethod
@@ -358,7 +348,7 @@ class NumRangeParameter(_NumericParameter):
         default_upper_value = default_upper_value if default_upper_value is not None else max_value
         curr_option = po.NumRangeParameterOption(min_value, max_value, increment, default_lower_value, default_upper_value)
         all_options = (curr_option,)
-        super().__init__(WidgetType.RangeField, name, label, all_options, is_hidden, None, curr_option)
+        super().__init__(name, label, all_options, is_hidden, None, curr_option)
         self._set_default_as_selection_mutate()
     
     @staticmethod

--- a/squirrels/renderer.py
+++ b/squirrels/renderer.py
@@ -74,11 +74,15 @@ class Renderer:
         except Exception as e:
             raise ConfigurationError(f'Error in the {c.CONTEXT_FILE} function for dataset "{self.dataset}"') from e
     
-    def _get_args(self, param_set: ParameterSet, context: Dict[str, Any]) -> Dict:
+    def _get_args(self, param_set: ParameterSet, context: Dict[str, Any], db_view: str = None) -> Dict:
+        if db_view is not None:
+            args = self.manifest.get_view_args(self.dataset, db_view)
+        else:
+            args = self.manifest.get_view_args(self.dataset)
         return {
             'prms': param_set,
             'ctx':  context,
-            'proj': self.manifest.get_proj_vars()
+            'args': args
         }
     
     def _render_query_from_raw(self, raw_query: Query, args: Dict) -> Query:
@@ -145,13 +149,14 @@ class Renderer:
         # render database view queries
         start = time.time()
         query_by_db_view = {}
-        args = self._get_args(param_set, context)
         for db_view, raw_query in self.raw_query_by_db_view.items():
+            args = self._get_args(param_set, context, db_view)
             query_by_db_view[db_view] = self._render_query_from_raw(raw_query, args)
         timer.add_activity_time(f"render database view queries - dataset {self.dataset}", start)
 
         # render final view query
         start = time.time()
+        args = self._get_args(param_set, context)
         final_view_query = self._render_query_from_raw(self.raw_final_view_query, args)
         timer.add_activity_time(f"render final view query - dataset {self.dataset}", start)
 
@@ -201,7 +206,7 @@ class RendererIOWrapper:
             db_view_template_path = str(manifest.get_database_view_file(dataset, db_view))
             raw_query_by_db_view[db_view] = self._get_raw_query(db_view_template_path)
         
-        final_view_path = str(manifest.get_dataset_final_view(dataset))
+        final_view_path = str(manifest.get_dataset_final_view_file(dataset))
         if final_view_path in db_views:
             raw_final_view_query = final_view_path
         else:

--- a/tests/connection_set_test.py
+++ b/tests/connection_set_test.py
@@ -31,7 +31,7 @@ def connection_set() -> cs.ConnectionSet:
         conn2.close()
     
     connection_set = cs.ConnectionSet({
-        "db1": pool1, 
+        "default": pool1, 
         "db2": pool2
     })
 

--- a/tests/param_configs/data_sources_test.py
+++ b/tests/param_configs/data_sources_test.py
@@ -35,7 +35,7 @@ class TestSelectionDataSource(TestParentParameters):
 
     def test_convert(self, multi_select_parent: sq.MultiSelectParameter, select_data_source: d.SelectionDataSource, 
                      select_data_source_with_parent: d.SelectionDataSource):
-        ds_param = d.DataSourceParameter(sq.WidgetType.SingleSelect, 'test_param', 'Test Parameter', select_data_source)
+        ds_param = d.DataSourceParameter(sq.SingleSelectParameter, 'test_param', 'Test Parameter', select_data_source)
         df = pd.DataFrame({
             'test_id': ['0', '1', '2'],
             'test_options': ['zero', 'one', 'two'],
@@ -43,7 +43,7 @@ class TestSelectionDataSource(TestParentParameters):
         })
         param_to_dict = select_data_source.convert(ds_param, df).to_dict()
         expected = {
-            'widget_type': 'SingleSelect',
+            'widget_type': 'SingleSelectParameter',
             'name': 'test_param',
             'label': 'Test Parameter',
             'options': [
@@ -56,7 +56,7 @@ class TestSelectionDataSource(TestParentParameters):
         }
         assert param_to_dict == expected
 
-        ds_param = d.DataSourceParameter(sq.WidgetType.SingleSelect, 'test_param', 'Test Parameter', select_data_source_with_parent,
+        ds_param = d.DataSourceParameter(sq.SingleSelectParameter, 'test_param', 'Test Parameter', select_data_source_with_parent,
                                        parent=multi_select_parent)
         df['parent_id'] = ['p1', 'p1', 'p2']
         converted_param = select_data_source_with_parent.convert(ds_param, df)
@@ -69,7 +69,7 @@ class TestSelectionDataSource(TestParentParameters):
         assert new_child.to_dict() == new_expected
     
     def test_invalid_column(self, select_data_source: d.SelectionDataSource):
-        ds_param = d.DataSourceParameter(sq.WidgetType.SingleSelect, 'test_param', 'Test Parameter', select_data_source)
+        ds_param = d.DataSourceParameter(sq.SingleSelectParameter, 'test_param', 'Test Parameter', select_data_source)
         df = pd.DataFrame({
             'invalid_name': ['0', '1', '2'],
             'test_options': ['zero', 'one', 'two'],
@@ -101,18 +101,18 @@ class TestDateDataSource(TestParentParameters):
 
     def test_convert(self, single_select_parent: sq.SingleSelectParameter, date_data_source: d.DateDataSource, 
                      date_data_source_with_parent: d.DateDataSource):
-        ds_param = d.DataSourceParameter(sq.WidgetType.DateField, 'test_param', 'Test Parameter', date_data_source)
+        ds_param = d.DataSourceParameter(sq.DateParameter, 'test_param', 'Test Parameter', date_data_source)
         df = pd.DataFrame({'date': ['2022-01-01']})
         param_to_dict = date_data_source.convert(ds_param, df).to_dict()
         expected = {
-            'widget_type': 'DateField',
+            'widget_type': 'DateParameter',
             'name': 'test_param',
             'label': 'Test Parameter',
             'selected_date': '2022-01-01'
         }
         assert param_to_dict == expected
 
-        ds_param = d.DataSourceParameter(sq.WidgetType.DateField, 'test_param', 'Test Parameter', date_data_source_with_parent,
+        ds_param = d.DataSourceParameter(sq.DateParameter, 'test_param', 'Test Parameter', date_data_source_with_parent,
                                        parent=single_select_parent)
         df = pd.DataFrame({
             'date': ['2020-01-01', '2021-01-01', '2022-01-01', '2023-01-01'],
@@ -140,11 +140,11 @@ class TestNumberDataSource(TestParentParameters):
 
     def test_convert(self, single_select_parent: sq.SingleSelectParameter, num_data_source: d.NumberDataSource, 
                      num_data_source_with_parent: d.NumberDataSource):
-        ds_param = d.DataSourceParameter(sq.WidgetType.NumberField, 'test_param', 'Test Parameter', num_data_source)
+        ds_param = d.DataSourceParameter(sq.NumberParameter, 'test_param', 'Test Parameter', num_data_source)
         df = pd.DataFrame([{ 'min_val': 0, 'max_val': 10, 'default_val': 2 }])
         param_to_dict = num_data_source.convert(ds_param, df).to_dict()
         expected = {
-            'widget_type': 'NumberField',
+            'widget_type': 'NumberParameter',
             'name': 'test_param',
             'label': 'Test Parameter',
             'min_value': '0',
@@ -154,7 +154,7 @@ class TestNumberDataSource(TestParentParameters):
         }
         assert param_to_dict == expected
 
-        ds_param = d.DataSourceParameter(sq.WidgetType.NumberField, 'test_param', 'Test Parameter', num_data_source_with_parent,
+        ds_param = d.DataSourceParameter(sq.NumberParameter, 'test_param', 'Test Parameter', num_data_source_with_parent,
                                        parent=single_select_parent)
         df = pd.DataFrame({
             'min_val': [0, 0, 4, 0],
@@ -188,11 +188,11 @@ class TestNumRangeDataSource(TestParentParameters):
 
     def test_convert(self, single_select_parent: sq.SingleSelectParameter, range_data_source: d.NumRangeDataSource, 
                      range_data_source_with_parent: d.NumRangeDataSource):
-        ds_param = d.DataSourceParameter(sq.WidgetType.RangeField, 'test_param', 'Test Parameter', range_data_source)
+        ds_param = d.DataSourceParameter(sq.NumRangeParameter, 'test_param', 'Test Parameter', range_data_source)
         df = pd.DataFrame([{ 'min_val': 0, 'max_val': 10, 'increment': 2, 'default_lower': 4, 'default_upper': 8 }])
         param_to_dict = range_data_source.convert(ds_param, df).to_dict()
         expected = {
-            'widget_type': 'RangeField',
+            'widget_type': 'NumRangeParameter',
             'name': 'test_param',
             'label': 'Test Parameter',
             'min_value': '0',
@@ -203,7 +203,7 @@ class TestNumRangeDataSource(TestParentParameters):
         }
         assert param_to_dict == expected
 
-        ds_param = d.DataSourceParameter(sq.WidgetType.RangeField, 'test_param', 'Test Parameter', range_data_source_with_parent,
+        ds_param = d.DataSourceParameter(sq.NumRangeParameter, 'test_param', 'Test Parameter', range_data_source_with_parent,
                                        parent=single_select_parent)
         df = pd.DataFrame({
             'min_val': [0, 0, 3, 0],

--- a/tests/param_configs/data_sources_test.py
+++ b/tests/param_configs/data_sources_test.py
@@ -8,10 +8,10 @@ import squirrels as sq
 
 
 class TestDataSource:
-    data_source1 = d.DataSource('conn', 'table_name')
-    data_source2 = d.DataSource('conn', 'select')
-    data_source3 = d.DataSource('conn', "SELECT * FROM table_name WHERE col = 'value'")
-    data_source4 = d.DataSource('conn', "select * from table_name where col = 'value'")
+    data_source1 = d.DataSource('table_name')
+    data_source2 = d.DataSource('select')
+    data_source3 = d.DataSource("SELECT * FROM table_name WHERE col = 'value'")
+    data_source4 = d.DataSource("select * from table_name where col = 'value'")
     
     def test_get_query(self):
         assert self.data_source1.get_query() == 'SELECT * FROM table_name'
@@ -22,7 +22,7 @@ class TestDataSource:
 
 class TestSelectionDataSource(TestParentParameters):
     def create_data_source(self, parent_id_col: Optional[str]):
-        return d.SelectionDataSource('conn', 'table', 'test_id', 'test_options',
+        return d.SelectionDataSource('table', 'test_id', 'test_options',
                                      is_default_col='test_is_default', parent_id_col=parent_id_col)
     
     @pytest.fixture
@@ -89,7 +89,7 @@ class TestSelectionDataSource(TestParentParameters):
 
 class TestDateDataSource(TestParentParameters):
     def create_data_source(self, parent_id_col: Optional[str]):
-        return d.DateDataSource('conn', 'table', 'date', parent_id_col=parent_id_col)
+        return d.DateDataSource('table', 'date', parent_id_col=parent_id_col)
     
     @pytest.fixture
     def date_data_source(self) -> d.DateDataSource:
@@ -127,7 +127,7 @@ class TestDateDataSource(TestParentParameters):
 
 class TestNumberDataSource(TestParentParameters):
     def create_data_source(self, parent_id_col: Optional[str]):
-        return d.NumberDataSource('conn', 'table', 'min_val', 'max_val', default_value_col='default_val', 
+        return d.NumberDataSource('table', 'min_val', 'max_val', default_value_col='default_val', 
                                 parent_id_col=parent_id_col) 
     
     @pytest.fixture
@@ -175,8 +175,8 @@ class TestNumberDataSource(TestParentParameters):
 
 class TestNumRangeDataSource(TestParentParameters):
     def create_data_source(self, parent_id_col: Optional[str]):
-        return d.NumRangeDataSource('conn', 'table', 'min_val', 'max_val', 'increment', 'default_lower', 
-                               'default_upper', parent_id_col=parent_id_col)
+        return d.NumRangeDataSource('table', 'min_val', 'max_val', 'increment', 'default_lower', 
+                                    'default_upper', parent_id_col=parent_id_col)
     
     @pytest.fixture
     def range_data_source(self) -> d.NumRangeDataSource:

--- a/tests/param_configs/parameter_set_test.py
+++ b/tests/param_configs/parameter_set_test.py
@@ -13,9 +13,9 @@ class TestParameterSet(TestParentParameters):
 
     @pytest.fixture
     def parameter_set(self, multi_select_parent: sq.MultiSelectParameter, ds_param_parent: sq.DataSourceParameter) -> ParameterSet:
-        child_param1 = sq.DataSourceParameter(sq.WidgetType.SingleSelect, 'child1', 'Test1 Parameter', self.select_data_source,
+        child_param1 = sq.DataSourceParameter(sq.SingleSelectParameter, 'child1', 'Test1 Parameter', self.select_data_source,
                                               parent=multi_select_parent)
-        child_param2 = sq.DataSourceParameter(sq.WidgetType.DateField, 'child2', 'Test2 Parameter', self.date_data_source,
+        child_param2 = sq.DataSourceParameter(sq.DateParameter, 'child2', 'Test2 Parameter', self.date_data_source,
                                               parent=ds_param_parent)
         return ParameterSet((multi_select_parent, child_param1, ds_param_parent, child_param2))
     
@@ -47,7 +47,7 @@ class TestParameterSet(TestParentParameters):
                                                  expected_ds_json: Dict):
         parameter_set.convert_datasource_params(df_dict)
         child1_expected = {
-            'widget_type': 'SingleSelect',
+            'widget_type': 'SingleSelectParameter',
             'name': 'child1',
             'label': 'Test1 Parameter',
             'options': [
@@ -61,12 +61,12 @@ class TestParameterSet(TestParentParameters):
             'selected_id': 'c1'
         }
         child2_expected = {
-            'widget_type': 'DateField',
+            'widget_type': 'DateParameter',
             'name': 'child2',
             'label': 'Test2 Parameter',
             'selected_date': '2021-06-14'
         }
-        expected_parent1 = self.get_expected_parent_json(sq.WidgetType.MultiSelect)
+        expected_parent1 = self.get_expected_parent_json(sq.MultiSelectParameter)
         expected_parent1['selected_ids'] = []
 
         actual = parameter_set.to_dict()['parameters']

--- a/tests/param_configs/parameter_set_test.py
+++ b/tests/param_configs/parameter_set_test.py
@@ -7,9 +7,9 @@ import squirrels as sq
 
 
 class TestParameterSet(TestParentParameters):
-    select_data_source = sq.SelectionDataSource('conn', 'table', 'id_val', 'option', is_default_col='is_default',
+    select_data_source = sq.SelectionDataSource('table', 'id_val', 'option', is_default_col='is_default',
                                                 parent_id_col='parent_id')
-    date_data_source = sq.DateDataSource('conn', 'table', 'date', parent_id_col='parent_id')
+    date_data_source = sq.DateDataSource('table', 'date', parent_id_col='parent_id')
 
     @pytest.fixture
     def parameter_set(self, multi_select_parent: sq.MultiSelectParameter, ds_param_parent: sq.DataSourceParameter) -> ParameterSet:

--- a/tests/param_configs/parameters_test.py
+++ b/tests/param_configs/parameters_test.py
@@ -31,7 +31,7 @@ class TestSingleSelectParameter(TestParentParameters):
             self.expected_parent_json = expected_parent_json
 
             self.partial_child_dict = {
-                'widget_type': 'SingleSelect',
+                'widget_type': 'SingleSelectParameter',
                 'name': 'child_param',
                 'label': 'Child Param',
                 'options': [],
@@ -39,7 +39,7 @@ class TestSingleSelectParameter(TestParentParameters):
             }
 
             self.partial_grandchild_dict = {
-                'widget_type': 'SingleSelect',
+                'widget_type': 'SingleSelectParameter',
                 'name': 'grandchild_param',
                 'label': 'Grandchild Param',
                 'options': [],
@@ -48,7 +48,7 @@ class TestSingleSelectParameter(TestParentParameters):
 
     @pytest.fixture
     def data(self, single_select_parent: p.SingleSelectParameter) -> ParameterData:
-        expected_parent_json = self.get_expected_parent_json(p.WidgetType.SingleSelect)
+        expected_parent_json = self.get_expected_parent_json(p.SingleSelectParameter)
         return self.ParameterData(single_select_parent, expected_parent_json)
     
     def test_refresh_with_selection(self, data: ParameterData):
@@ -130,7 +130,7 @@ class TestMultiSelectParameter(TestParentParameters):
             self.expected_parent_json = expected_parent_json
 
             self.partial_child_dict = {
-                'widget_type': 'SingleSelect',
+                'widget_type': 'SingleSelectParameter',
                 'name': 'child_param',
                 'label': 'Child Param',
                 'options': [],
@@ -138,7 +138,7 @@ class TestMultiSelectParameter(TestParentParameters):
             }
 
             self.partial_grandchild_dict = {
-                'widget_type': 'MultiSelect',
+                'widget_type': 'MultiSelectParameter',
                 'name': 'grandchild_param',
                 'label': 'Grandchild Param',
                 'options': [],
@@ -149,7 +149,7 @@ class TestMultiSelectParameter(TestParentParameters):
 
     @pytest.fixture
     def data(self, multi_select_parent: p.MultiSelectParameter) -> ParameterData:
-        expected_parent_json = self.get_expected_parent_json(p.WidgetType.MultiSelect)
+        expected_parent_json = self.get_expected_parent_json(p.MultiSelectParameter)
         return self.ParameterData(multi_select_parent, expected_parent_json)
     
     def test_refresh_with_selection(self, data: ParameterData):
@@ -230,7 +230,7 @@ class TestDateParameter(TestParentParameters):
         new_date_param = self.date_parameter.with_selection('2023-01-01')
 
         expected = {
-            'widget_type': 'DateField',
+            'widget_type': 'DateParameter',
             'name': 'date',
             'label': 'Date Value',
             'selected_date': '2020-01-01'
@@ -251,7 +251,7 @@ class TestDateParameter(TestParentParameters):
         new_parent = single_select_parent.with_selection('p2')
 
         expected = {
-            'widget_type': 'DateField',
+            'widget_type': 'DateParameter',
             'name': 'child',
             'label': 'Child Param',
             'selected_date': '2020-01-01'
@@ -303,7 +303,7 @@ class TestNumberParameter(TestParentParameters):
         new_num_param = self.number_parameter.with_selection('4')
 
         expected = {
-            'widget_type': 'NumberField',
+            'widget_type': 'NumberParameter',
             'name': 'number',
             'label': 'Number Value',
             'min_value': '0',
@@ -326,7 +326,7 @@ class TestNumberParameter(TestParentParameters):
         new_parent = single_select_parent.with_selection('p2')
 
         expected = {
-            'widget_type': 'NumberField',
+            'widget_type': 'NumberParameter',
             'name': 'child',
             'label': 'Child Param',
             'min_value': '0',
@@ -379,7 +379,7 @@ class TestNumRangeParameter(TestParentParameters):
         new_num_param = self.range_parameter.with_selection('2,8')
 
         expected = {
-            'widget_type': 'RangeField',
+            'widget_type': 'NumRangeParameter',
             'name': 'range',
             'label': 'Range Value',
             'min_value': '0',
@@ -404,7 +404,7 @@ class TestNumRangeParameter(TestParentParameters):
         new_parent = single_select_parent.with_selection('p2')
 
         expected = {
-            'widget_type': 'RangeField',
+            'widget_type': 'NumRangeParameter',
             'name': 'child',
             'label': 'Child Param',
             'min_value': '0',

--- a/tests/param_configs/parent_parameters.py
+++ b/tests/param_configs/parent_parameters.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Dict
+from typing import Type, Sequence, Dict
 import pytest, pandas as pd
 
 import squirrels as sq
@@ -16,14 +16,14 @@ class TestParentParameters:
         'trigger_refresh': True
     }
     
-    def get_expected_parent_json(self, widget_type: sq.WidgetType):
+    def get_expected_parent_json(self, widget_type: Type[sq.Parameter]):
         expected = dict(self.expected_base)
-        if widget_type == sq.WidgetType.SingleSelect:
+        if widget_type == sq.SingleSelectParameter:
             expected['name'] = 'ss_parent'
-            expected['widget_type'] = widget_type.name
-        elif widget_type == sq.WidgetType.MultiSelect:
+            expected['widget_type'] = widget_type.__name__
+        elif widget_type == sq.MultiSelectParameter:
             expected['name'] = 'ms_parent'
-            expected['widget_type'] = widget_type.name
+            expected['widget_type'] = widget_type.__name__
             expected.update({
                 'include_all': True,
                 'order_matters': False
@@ -49,7 +49,7 @@ class TestParentParameters:
                                                 is_default_col='is_default')
     @pytest.fixture
     def ds_param_parent(self) -> sq.DataSourceParameter:
-        return sq.DataSourceParameter(sq.WidgetType.SingleSelect, 'ds_parent', 'Parent Param', self.parent_data_source)
+        return sq.DataSourceParameter(sq.SingleSelectParameter, 'ds_parent', 'Parent Param', self.parent_data_source)
     
     @pytest.fixture
     def data_source_df(self) -> pd.DataFrame:
@@ -63,7 +63,7 @@ class TestParentParameters:
     @pytest.fixture
     def expected_ds_json(self) -> Dict:
         return {
-            'widget_type': 'SingleSelect',
+            'widget_type': 'SingleSelectParameter',
             'name': 'ds_parent',
             'label': 'Parent Param',
             'options': [

--- a/tests/param_configs/parent_parameters.py
+++ b/tests/param_configs/parent_parameters.py
@@ -45,8 +45,8 @@ class TestParentParameters:
     def multi_select_parent(self, parent_options: Sequence[sq.SelectParameterOption]) -> sq.MultiSelectParameter:
         return sq.MultiSelectParameter('ms_parent', 'Parent Param', parent_options)
 
-    parent_data_source = sq.SelectionDataSource('conn', 'table', 'id_val', 'options', order_by_col='order_by',
-                                      is_default_col='is_default')
+    parent_data_source = sq.SelectionDataSource('table', 'id_val', 'options', order_by_col='order_by',
+                                                is_default_col='is_default')
     @pytest.fixture
     def ds_param_parent(self) -> sq.DataSourceParameter:
         return sq.DataSourceParameter(sq.WidgetType.SingleSelect, 'ds_parent', 'Parent Param', self.parent_data_source)

--- a/tests/renderer_test.py
+++ b/tests/renderer_test.py
@@ -14,9 +14,10 @@ class TestRenderer:
             "datasets": {
                 "avg_shop_price_by_city": {
                     "database_views": {
-                        "shop_city_view": {"db_connection": "test_db1"},
+                        "shop_city_view": {},
                         "avg_prices_view": {"db_connection": "test_db2"}
-                    }
+                    },
+                    "final_view": ""
                 }
             }
         }
@@ -48,7 +49,7 @@ class TestRenderer:
             conn2.close()
         
         connection_set = cs.ConnectionSet({
-            "test_db1": pool1, 
+            "default": pool1, 
             "test_db2": pool2
         })
 
@@ -57,7 +58,7 @@ class TestRenderer:
     
     @pytest.fixture
     def raw_param_set(self) -> sq.ParameterSet:
-        city_ds = sq.SelectionDataSource("test_db1", "lu_cities", "city_id", "city")
+        city_ds = sq.SelectionDataSource("lu_cities", "city_id", "city")
         city_param = sq.DataSourceParameter(sq.WidgetType.MultiSelect, "city", "City", city_ds)
         price_limit = sq.NumberParameter('limit', 'Limit', 0, 100)
         return sq.ParameterSet([city_param, price_limit])

--- a/tests/renderer_test.py
+++ b/tests/renderer_test.py
@@ -59,7 +59,7 @@ class TestRenderer:
     @pytest.fixture
     def raw_param_set(self) -> sq.ParameterSet:
         city_ds = sq.SelectionDataSource("lu_cities", "city_id", "city")
-        city_param = sq.DataSourceParameter(sq.WidgetType.MultiSelect, "city", "City", city_ds)
+        city_param = sq.DataSourceParameter(sq.MultiSelectParameter, "city", "City", city_ds)
         price_limit = sq.NumberParameter('limit', 'Limit', 0, 100)
         return sq.ParameterSet([city_param, price_limit])
 


### PR DESCRIPTION
Originally, in addition to a "squirrels.yaml" file, we also have mandatory "project_vars.yaml" and "connections.py" files. In the new design, the project variables and connections can be configured in squirrels.yaml instead, the "project_vars.yaml" file goes away entirely, and "connections.py" is optional to be able to configure connections with python if needed.